### PR TITLE
Simplify the beginning of the codelab

### DIFF
--- a/FriendlyEats.xcodeproj/project.pbxproj
+++ b/FriendlyEats.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		496B609A203363A9005AD625 /* ReviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496B6099203363A9005AD625 /* ReviewTableViewCell.swift */; };
 		499D8970203CD176009C067E /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499D896F203CD176009C067E /* Utils.swift */; };
 		49C24867202A237000D6008A /* HackPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C24866202A237000D6008A /* HackPageViewController.swift */; };
+		49DEA0D7205B19AC00F2A452 /* BasicRestaurantsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DEA0D6205B19AC00F2A452 /* BasicRestaurantsTableViewController.swift */; };
+		49DEA0D9205B19D900F2A452 /* RestaurantTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DEA0D8205B19D900F2A452 /* RestaurantTableViewCell.swift */; };
 		8D004D2D1EE879B5004DEF35 /* FiltersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */; };
 		8D2A2A0B202BC3B600343C13 /* ReviewTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2A2A0A202BC3B600343C13 /* ReviewTableViewDataSource.swift */; };
 		8D5DF7021F7EF3BA00B0D24F /* NewReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */; };
@@ -50,6 +52,8 @@
 		496B6099203363A9005AD625 /* ReviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTableViewCell.swift; sourceTree = "<group>"; };
 		499D896F203CD176009C067E /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		49C24866202A237000D6008A /* HackPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackPageViewController.swift; sourceTree = "<group>"; };
+		49DEA0D6205B19AC00F2A452 /* BasicRestaurantsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicRestaurantsTableViewController.swift; sourceTree = "<group>"; };
+		49DEA0D8205B19D900F2A452 /* RestaurantTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantTableViewCell.swift; sourceTree = "<group>"; };
 		8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FiltersViewController.swift; sourceTree = "<group>"; };
 		8D2A2A0A202BC3B600343C13 /* ReviewTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTableViewDataSource.swift; sourceTree = "<group>"; };
 		8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewReviewViewController.swift; sourceTree = "<group>"; };
@@ -105,6 +109,8 @@
 				360549AB2028D56E0090317C /* EditRestaurantViewController.swift */,
 				8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */,
 				8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */,
+				49DEA0D6205B19AC00F2A452 /* BasicRestaurantsTableViewController.swift */,
+				49DEA0D8205B19D900F2A452 /* RestaurantTableViewCell.swift */,
 			);
 			path = Restaurants;
 			sourceTree = "<group>";
@@ -238,7 +244,6 @@
 				TargetAttributes = {
 					8D9BBC2C1EE2200900194E9A = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = 739D5HF686;
 						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
@@ -300,6 +305,7 @@
 				8D9BBC311EE2200900194E9A /* AppDelegate.swift in Sources */,
 				8D82F5C1201FCE2500107172 /* Review.swift in Sources */,
 				8DF1E3151EE72C4600192CDE /* LocalCollection.swift in Sources */,
+				49DEA0D7205B19AC00F2A452 /* BasicRestaurantsTableViewController.swift in Sources */,
 				8D6014FC202B8B23003E8091 /* ProfileViewController.swift in Sources */,
 				8D5DF7021F7EF3BA00B0D24F /* NewReviewViewController.swift in Sources */,
 				8DDCD366203277CA00CFBF60 /* AddRestaurantViewController.swift in Sources */,
@@ -308,6 +314,7 @@
 				8DF77E1A1EEB45E500CB2330 /* RestaurantDetailViewController.swift in Sources */,
 				8D70C1BA201FECE2007D3082 /* Firestore+Populate.swift in Sources */,
 				360549AC2028D56E0090317C /* EditRestaurantViewController.swift in Sources */,
+				49DEA0D9205B19D900F2A452 /* RestaurantTableViewCell.swift in Sources */,
 				8D004D2D1EE879B5004DEF35 /* FiltersViewController.swift in Sources */,
 				8DDCD364203261A500CFBF60 /* RestaurantTableViewDataSource.swift in Sources */,
 				8D82F5C5201FE6CE00107172 /* Yum.swift in Sources */,
@@ -468,7 +475,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 739D5HF686;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FriendlyEats/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.FriendlyEats;
@@ -482,7 +489,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 739D5HF686;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FriendlyEats/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.FriendlyEats;

--- a/FriendlyEats/Base.lproj/Main.storyboard
+++ b/FriendlyEats/Base.lproj/Main.storyboard
@@ -153,7 +153,7 @@
         <!--Restaurants-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController title="Restaurants" automaticallyAdjustsScrollViewInsets="NO" id="BYZ-38-t0r" customClass="RestaurantsTableViewController" customModule="FriendlyEats" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Restaurants" automaticallyAdjustsScrollViewInsets="NO" id="BYZ-38-t0r" customClass="BasicRestaurantsTableViewController" customModule="FriendlyEats" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>

--- a/FriendlyEats/Restaurants/BasicRestaurantsTableViewController.swift
+++ b/FriendlyEats/Restaurants/BasicRestaurantsTableViewController.swift
@@ -1,0 +1,112 @@
+//
+//  Copyright (c) 2018 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import Firebase
+
+class BasicRestaurantsTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+
+  @IBOutlet var tableView: UITableView!
+  // You can ignore these properties. They're used later on in the workshop.
+  @IBOutlet var activeFiltersStackView: UIStackView!
+  @IBOutlet var stackViewHeightConstraint: NSLayoutConstraint!
+  @IBOutlet var cityFilterLabel: UILabel!
+  @IBOutlet var categoryFilterLabel: UILabel!
+  @IBOutlet var priceFilterLabel: UILabel!
+
+
+  let backgroundView = UIImageView()
+  var restaurantData: [Restaurant] = []
+  var restaurantListener: ListenerRegistration?
+
+  private func startListeningForRestaurants() {
+    // TODO: Create a listener for the "restaurants" collection and use that data
+    // to popualte our `restaurantData` model
+  }
+
+  func tryASampleQuery() {
+    // TODO: Let's put a sample query here to see how basic data fetching works in
+    // Cloud Firestore
+  }
+
+  private func stopListeningForRestaurants() {
+    // TODO: We should "deactivate" our restaurant listener when this view goes away
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    backgroundView.image = UIImage(named: "pizza-monster")!
+    backgroundView.contentMode = .scaleAspectFit
+    backgroundView.alpha = 0.5
+    tableView.backgroundView = backgroundView
+    tableView.tableFooterView = UIView()
+    stackViewHeightConstraint.constant = 0
+    activeFiltersStackView.isHidden = true
+    tableView.delegate = self
+    tableView.dataSource = self
+    tryASampleQuery()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    setNeedsStatusBarAppearanceUpdate()
+    startListeningForRestaurants()
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    stopListeningForRestaurants()
+  }
+
+  // MARK: - Table view data source
+
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return 1
+  }
+
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return restaurantData.count
+  }
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "RestaurantTableViewCell",
+                                             for: indexPath) as! RestaurantTableViewCell
+    let restaurant = restaurantData[indexPath.row]
+    cell.populate(restaurant: restaurant)
+    return cell
+  }
+
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    let restaurant = restaurantData[indexPath.row]
+    let controller = RestaurantDetailViewController.fromStoryboard(restaurant: restaurant)
+    self.navigationController?.pushViewController(controller, animated: true)
+  }
+
+  @IBAction func didTapPopulateButton(_ sender: Any) {
+    let confirmationBox = UIAlertController(title: "Populate the database",
+                                            message: "This will add populate the database with several new restaurants and reviews. Would you like to proceed?",
+                                            preferredStyle: .alert)
+    confirmationBox.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+    confirmationBox.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in
+      Firestore.firestore().prepopulate()
+    }))
+    present(confirmationBox, animated: true)
+  }
+
+}
+
+

--- a/FriendlyEats/Restaurants/RestaurantTableViewCell.swift
+++ b/FriendlyEats/Restaurants/RestaurantTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright (c) 2016 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import UIKit
+
+
+class RestaurantTableViewCell: UITableViewCell {
+
+  @IBOutlet private var thumbnailView: UIImageView!
+
+  @IBOutlet private var nameLabel: UILabel!
+
+  @IBOutlet var starsView: ImmutableStarsView!
+
+  @IBOutlet private var cityLabel: UILabel!
+
+  @IBOutlet private var categoryLabel: UILabel!
+
+  @IBOutlet private var priceLabel: UILabel!
+
+  func populate(restaurant: Restaurant) {
+    // TODO: Fill this out
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    thumbnailView.sd_cancelCurrentImageLoad()
+  }
+
+}
+

--- a/FriendlyEats/Restaurants/RestaurantsTableViewController.swift
+++ b/FriendlyEats/Restaurants/RestaurantsTableViewController.swift
@@ -198,27 +198,3 @@ extension RestaurantsTableViewController: FiltersViewControllerDelegate {
 
 }
 
-class RestaurantTableViewCell: UITableViewCell {
-
-  @IBOutlet private var thumbnailView: UIImageView!
-
-  @IBOutlet private var nameLabel: UILabel!
-
-  @IBOutlet var starsView: ImmutableStarsView!
-
-  @IBOutlet private var cityLabel: UILabel!
-
-  @IBOutlet private var categoryLabel: UILabel!
-
-  @IBOutlet private var priceLabel: UILabel!
-
-  func populate(restaurant: Restaurant) {
-
-  }
-
-  override func prepareForReuse() {
-    super.prepareForReuse()
-    thumbnailView.sd_cancelCurrentImageLoad()
-  }
-
-}


### PR DESCRIPTION
I wanted to kinda split up the "Let's show you how to load data from firestore" and "Let's refactor our dataSource object" into separate steps in the codelab. This seemed like the simplest way to do it.

1. Added a “BasicRestaurantsTableViewController” that will let us show the basic abilities to fetch documents from a collection before we start refactoring
2. Moved the RestaurantTableViewCell into a separate file
3. (Unrelated) Changed our team to “No team”

This will obviously also need a corresponding change in the codelab, which I'm in the middle of writing.